### PR TITLE
Response times for urls matt

### DIFF
--- a/app/models/url.rb
+++ b/app/models/url.rb
@@ -14,4 +14,8 @@ class Url < ActiveRecord::Base
   def most_popular
     payload_requests.group(:referrer_id).order('count(*) DESC').limit(3).count.keys
   end
+
+  def average_response_time
+    payload_requests.average_response_time
+  end
 end

--- a/app/models/url.rb
+++ b/app/models/url.rb
@@ -3,4 +3,7 @@ class Url < ActiveRecord::Base
 
   validates :url_path, presence: true
 
+  def min_response_time
+    payload_requests.min_response_time
+  end
 end

--- a/app/models/url.rb
+++ b/app/models/url.rb
@@ -10,4 +10,8 @@ class Url < ActiveRecord::Base
   def response_times
     payload_requests.map { |pl| pl.responded_in }.sort.reverse
   end
+
+  def most_popular
+    payload_requests.group(:referrer_id).order('count(*) DESC').limit(3).count.keys
+  end
 end

--- a/app/models/url.rb
+++ b/app/models/url.rb
@@ -6,4 +6,8 @@ class Url < ActiveRecord::Base
   def min_response_time
     payload_requests.min_response_time
   end
+
+  def response_times
+    payload_requests.map { |pl| pl.responded_in }.sort.reverse
+  end
 end

--- a/test/models/url_test.rb
+++ b/test/models/url_test.rb
@@ -108,4 +108,21 @@ class UrlsTest < Minitest::Test
 
     assert_equal [3, 4, 1], url_data_1.most_popular
   end
+
+  def test_average_response_time_test_the_average_response_time_for_this_url
+    payload_data_1 = get_payload_data
+    payload_data_1["responded_in"] = 10
+    payload_data_2 = get_payload_data
+    payload_data_2["responded_in"] = 20
+    payload_data_3 = get_payload_data
+    payload_data_3["responded_in"] = 30
+
+    PayloadRequest.create(payload_data_1)
+    PayloadRequest.create(payload_data_2)
+    PayloadRequest.create(payload_data_3)
+
+    url_data_1 = create_params
+
+    assert_equal 20, url_data_1.average_response_time
+  end
 end

--- a/test/models/url_test.rb
+++ b/test/models/url_test.rb
@@ -64,8 +64,7 @@ class UrlsTest < Minitest::Test
   end
 
   def test_a_list_of_response_time_across_all_requests_listed_from_longest_to_shortest
-  # A list of response times across all
-  # requests listed from longest response time to shortest response time.
+    #don't know whether to join the string or leave a array
   payload_data_1 = get_payload_data
   payload_data_1["responded_in"] = 10
   payload_data_2 = get_payload_data
@@ -82,5 +81,31 @@ class UrlsTest < Minitest::Test
   assert_equal [30, 20, 10], url_data_1.response_times
   end
 
-  
+  def test_most_popular_finds_the_three_most_popular_referrers
+    #lowest referrer id wins ties
+    #left in an array
+    payload_data_1 = get_payload_data
+    payload_data_1["referrer_id"] = 1
+    payload_data_2 = get_payload_data
+    payload_data_2["referrer_id"] = 3
+    payload_data_3 = get_payload_data
+    payload_data_3["referrer_id"] = 3
+    payload_data_4 = get_payload_data
+    payload_data_4["referrer_id"] = 2
+    payload_data_5 = get_payload_data
+    payload_data_5["referrer_id"] = 4
+    payload_data_6 = get_payload_data
+    payload_data_6["referrer_id"] = 4
+
+    PayloadRequest.create(payload_data_1)
+    PayloadRequest.create(payload_data_2)
+    PayloadRequest.create(payload_data_3)
+    PayloadRequest.create(payload_data_4)
+    PayloadRequest.create(payload_data_5)
+    PayloadRequest.create(payload_data_6)
+
+    url_data_1 = create_params
+
+    assert_equal [3, 4, 1], url_data_1.most_popular
+  end
 end

--- a/test/models/url_test.rb
+++ b/test/models/url_test.rb
@@ -57,12 +57,29 @@ class UrlsTest < Minitest::Test
     PayloadRequest.create(payload_data_2)
     PayloadRequest.create(payload_data_3)
 
-    params = {"url_path"=>"http://www.google.com"}
-
     url_data_1 = create_params
     url_data_2 = create_params
 
     assert_equal 10, url_data_2.min_response_time
+  end
+
+  def test_a_list_of_response_time_across_all_requests_listed_from_longest_to_shortest
+  # A list of response times across all
+  # requests listed from longest response time to shortest response time.
+  payload_data_1 = get_payload_data
+  payload_data_1["responded_in"] = 10
+  payload_data_2 = get_payload_data
+  payload_data_2["responded_in"] = 20
+  payload_data_3 = get_payload_data
+  payload_data_3["responded_in"] = 30
+
+  PayloadRequest.create(payload_data_1)
+  PayloadRequest.create(payload_data_2)
+  PayloadRequest.create(payload_data_3)
+
+  url_data_1 = create_params
+
+  assert_equal [30, 20, 10], url_data_1.response_times
   end
 
   

--- a/test/models/url_test.rb
+++ b/test/models/url_test.rb
@@ -42,4 +42,28 @@ class UrlsTest < Minitest::Test
     assert_equal payload, url.payload_requests.first
   end
 
+  def test_that_min_response_time_of_payload_requests_is_calculated
+    payload_data_1 = get_payload_data
+    payload_data_1["responded_in"] = 10
+    payload_data_1["url_id"] = 2
+    payload_data_2 = get_payload_data
+    payload_data_2["responded_in"] = 20
+    payload_data_2["url_id"] = 2
+    payload_data_3 = get_payload_data
+    payload_data_3["responded_in"] = 30
+    payload_data_3["url_id"] = 2
+
+    PayloadRequest.create(payload_data_1)
+    PayloadRequest.create(payload_data_2)
+    PayloadRequest.create(payload_data_3)
+
+    params = {"url_path"=>"http://www.google.com"}
+
+    url_data_1 = create_params
+    url_data_2 = create_params
+
+    assert_equal 10, url_data_2.min_response_time
+  end
+
+  
 end


### PR DESCRIPTION
Methods added to Url

*min_response_time
    %method on Url object

*response_times
    %populates an array of response times for payload requests associated with the url from longest to shortest

*most_popular
    %finds the three most popular referrers associated with the payload request

*average_response_time
    %method on Url object
